### PR TITLE
b/f: use rtpengine_manage in all cases when rewriting SDP

### DIFF
--- a/etc/kamailio/kamailio.cfg
+++ b/etc/kamailio/kamailio.cfg
@@ -611,7 +611,7 @@ route[RTP_BRIDGE] {
 			t_on_reply("REPLY_FROM_WS");
 		} else if ($proto =~ "ws") {
 			xlog("L_INFO", "WebRTC -> SIP, bridging SRTP->RTP and removing ICE");
-			rtpengine_offer("trust-address replace-origin replace-session-connection rtcp-mux-demux ICE=remove RTP/AVP");
+			rtpengine_manage("trust-address replace-origin replace-session-connection rtcp-mux-demux ICE=remove RTP/AVP");
 			t_on_reply("REPLY_TO_WS");
 		}
 	}


### PR DESCRIPTION
if rtpengine_offer is used on the INVITE and rtpengine_manage on the 200,
the rtpengine module uses both times the 'offer' command, and rtpengine
will use setup=actpass in the reply's SDP, too

this looks like a leftover/typo in the config 