### PR TITLE
b/f:use NAT handling for 183->180 replies, too

### DIFF
--- a/etc/kamailio/kamailio.cfg
+++ b/etc/kamailio/kamailio.cfg
@@ -630,6 +630,7 @@ onreply_route[REPLY_TO_WS] {
 	if (t_check_status("183")) {
 		change_reply_status("180", "Ringing");
 		remove_body();
+		route(NATMANAGE);
 		exit;
 	}
 


### PR DESCRIPTION
183 replies which are changed to 180s should be handled
by route(NATMANAGE), otherwise the Contact of the 180s are
not fixed which could break the ACK if using other WebRTC-SIP
libraries (e.g. jssip) which don't update the r-URI by the
Contact from the 200