### PR TITLE
Update GPG keys for SIPWise repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The easiest way of installing is to get it from Sipwise repository:
 ```bash
 echo 'deb https://deb.sipwise.com/spce/mr9.4.1/ buster main' > /etc/apt/sources.list.d/sipwise.list
 echo 'deb-src https://deb.sipwise.com/spce/mr9.4.1/ buster main' >> /etc/apt/sources.list.d/sipwise.list
-wget -q -O - https://deb.sipwise.com/spce/sipwise.gpg | apt-key add -
+wget -q -O - https://deb.sipwise.com/spce/keyring/sipwise-keyring-bootstrap.gpg | apt-key add -
 apt-get update
 apt-get install -y ngcp-keyring ngcp-rtpengine
 ```


### PR DESCRIPTION
According to https://www.sipwise.com/spce/blog/update-of-a-sipwise-public-gpg-key/, the GPG keys used to sign the package are at the indicated location.